### PR TITLE
More Selective backups

### DIFF
--- a/workspaces/idapp/CONFLUENZA.md
+++ b/workspaces/idapp/CONFLUENZA.md
@@ -1,0 +1,6 @@
+---
+path: /services/idapp
+title: Identity App
+tag: service
+content: README.md
+---

--- a/workspaces/idapp/README.md
+++ b/workspaces/idapp/README.md
@@ -28,3 +28,51 @@ what's actually going on.
 $ expo-env --env=<your-configuration>
 $ yarn start [--clear]
 ```
+## Publishing to TestFlight
+
+> This documentation applies to Xcode v11.
+
+### Update build/version number for the app
+
+In `config.json` we have two attributes related to versioning of the app: `version` and `ios.buildNumber`. Before publishing the app to TestFlight one of the two needs to be updated. Currently we keep `version` fixed to `1.0.0`, and for each new build we just increase the build number.
+
+> Here we are concerned with the iOS build, but notice that there is also attribute `android.versionCode` which plays the same role as `ios.buildNumber`. When increasing `ios.buildNumber` we also increase `android.versionCode`.
+
+### Apply the build configuration
+
+Run `yarn env:prod` from the terminal.
+
+> All commands need to be run from the `workspaces/idapp` folder.
+
+### Create iOS build
+
+Run `expo build:ios` from the terminal. Once the build is finished download the corresponding `.ipa` file.
+
+### Upload the build to Apple Connect
+
+> Here I assume you have your Apple Connect configured. In particular you have generated an App Specific password for your account. If you need some guidance on the whole process you may like to consult [React Native: How To Publish An Expo App To TestFlight + Debug Common Errors] and the official Expo documentation [Uploading Apps to the Apple App Store and Google Play].
+
+The `expo upload:ios` command is temporarily unavailable due to changes in Xcode 11 - as stated in the Expo documentation - this is why we have to use `xcrun` command. The command you have to run is:
+
+```bash
+xcrun altool --upload-app -f <PATH-TO-IPA-FILE> -u <YOUR APPLE-ID>
+```
+
+You will be asked for the password.
+
+> If you have 2FA enabled for your AppleId, you will need to create an App-specific password and provide it here.
+
+It may take some time before the uploading of the app finishes. There will be no feedback or progress indication in the meantime. If everything worked out, you will just see `No errors uploading 'YOUR IPA FILE NAME'`. In case it did not work, you will get some information about the error, in which case [this thread](https://github.com/expo/expo-cli/issues/927) may help.
+
+### Make your build ready on the Apple Connect portal
+
+You may need to wait a bit before the processing of your build finishes on iTunes. You will get an email from iTunes Store saying that your new build has completed processing (and you will most probably ignore an email about ITMS-90809: Deprecated API Usage for UIWebView - we hope this will be fixed by Expo team soon).
+
+You will also like to include additional information about your build so that your testers know what's new in this build that needs to be tested.
+
+> We noticed that entering this description on Safari makes the portal unresponsive - Google Chrome worked just fine...
+
+
+[React Native: How To Publish An Expo App To TestFlight + Debug Common Errors]: https://levelup.gitconnected.com/react-native-how-to-publish-an-expo-app-to-testflight-debug-common-errors-90e427b4b5ea
+
+[Uploading Apps to the Apple App Store and Google Play]: https://docs.expo.io/versions/v35.0.0/distribution/uploading-apps/

--- a/workspaces/idapp/config.json
+++ b/workspaces/idapp/config.json
@@ -24,10 +24,10 @@
       "**/*"
     ],
     "android": {
-      "versionCode": 1
+      "versionCode": 2
     },
     "ios": {
-      "buildNumber": "0.1.1",
+      "buildNumber": "0.1.2",
       "bundleIdentifier": "sh.now.idapp",
       "supportsTablet": true,
       "infoPlist": {

--- a/workspaces/idapp/src/views/settings/BackupMnemonic.js
+++ b/workspaces/idapp/src/views/settings/BackupMnemonic.js
@@ -92,7 +92,7 @@ const BackupMnemonic = ({ navigation }) => {
                 />
               </>
             )
-            : <Text style={{ textAlign: 'center', marginBottom: 50 }}>Creating first backup...</Text>
+            : <Text style={{ textAlign: 'center', marginBottom: 50 }}>Enabling backup...</Text>
         }
       </Subcontainer>
     </Container>

--- a/workspaces/idapp/src/views/settings/BackupMnemonic.js
+++ b/workspaces/idapp/src/views/settings/BackupMnemonic.js
@@ -17,13 +17,14 @@ const BackupMnemonic = ({ navigation }) => {
     navigation.navigate('Settings')
   }, [])
 
-  const writeBackupToIdBox = async (telepathProvider, encryptedBackup, backupId) => {
+  const writeBackupToIdBox = async (telepathProvider, encryptedBackup, backupId, identityNames) => {
     const message = {
       jsonrpc: '2.0',
       method: 'backup',
       params: [{
         encryptedBackup,
-        backupId
+        backupId,
+        identityNames
       }, {
         from: telepathProvider.clientId
       }]
@@ -51,7 +52,7 @@ const BackupMnemonic = ({ navigation }) => {
       setMnemonic(mnemonic)
       Clipboard.setString(mnemonic)
       console.log('encryptedBackup=', encryptedBackup)
-      writeBackupToIdBox(telepathProvider, encryptedBackup, backupId)
+      writeBackupToIdBox(telepathProvider, encryptedBackup, backupId, identityManager.identityNames)
     },
     onMessage: async message => {
       console.log('received message: ', message)

--- a/workspaces/idapp/src/views/settings/ConfirmFactoryReset.js
+++ b/workspaces/idapp/src/views/settings/ConfirmFactoryReset.js
@@ -33,11 +33,13 @@ const ConfirmFactoryReset = ({ navigation }) => {
     }
   })
 
-  const resetIdBox = async telepathProvider => {
+  const resetIdBox = async (telepathProvider, identityNames) => {
     const message = {
       jsonrpc: '2.0',
       method: 'reset',
-      params: [{}, {
+      params: [{
+        identityNames
+      }, {
         from: telepathProvider.clientId
       }]
     }
@@ -52,8 +54,9 @@ const ConfirmFactoryReset = ({ navigation }) => {
 
   const onPerformReset = useCallback(async () => {
     console.log('will perform factory reset now...')
+    const identityNames = identityManager.identityNames
     await identityManager.reset()
-    resetIdBox(telepathProvider)
+    resetIdBox(telepathProvider, identityNames)
   }, [identityManager, telepathProvider])
 
   return (

--- a/workspaces/idapp/src/views/settings/RestoreFromBackup.js
+++ b/workspaces/idapp/src/views/settings/RestoreFromBackup.js
@@ -42,7 +42,6 @@ const RestoreFromBackup = ({ navigation }) => {
       telepathProvider.current = tp
     },
     onMessage: async message => {
-      setInProgress(false)
       console.log('received message: ', message)
       if (message.method === 'restore-response') {
         const { encryptedBackup } = message.params[0]

--- a/workspaces/idservice/src/entry-point/IdService.js
+++ b/workspaces/idservice/src/entry-point/IdService.js
@@ -219,7 +219,8 @@ class IdService {
   }
 
   handleReset = async message => {
-    await this.identityProvider.deleteAll()
+    const { identityNames } = message.params[0]
+    await this.identityProvider.deleteAll(identityNames)
     this.respond('reset-response', message.params[1].from)
   }
 

--- a/workspaces/idservice/src/identity/IdentityProvider.js
+++ b/workspaces/idservice/src/identity/IdentityProvider.js
@@ -57,8 +57,9 @@ class IdentityProvider {
     return match && match[1]
   }
 
-  deleteAll = async () => {
-    const keys = await this.ipfs.key.list()
+  deleteAll = async identityNames => {
+    const allKeys = await this.ipfs.key.list()
+    const keys = allKeys.filter(k => identityNames.includes(k.name))
     await Promise.all(keys.map(async ({ name }) => {
       if (name === 'self') return
       console.log('deleting key: ', name)

--- a/workspaces/idservice/src/identity/IdentityProvider.js
+++ b/workspaces/idservice/src/identity/IdentityProvider.js
@@ -125,10 +125,11 @@ class IdentityProvider {
     fs.mkdirSync(this.getBackupFolderPath(backupId), { recursive: true, mode: 0o755 })
   }
 
-  backup = async ({ encryptedBackup, backupId }) => {
+  backup = async ({ encryptedBackup, backupId, identityNames }) => {
     this.createBackupFolders(backupId)
     this.backupIds(encryptedBackup, backupId)
-    const keys = await this.ipfs.key.list()
+    const allKeys = await this.ipfs.key.list()
+    const keys = allKeys.filter(k => identityNames.includes(k.name))
     await Promise.all(keys.map(async ({ name, id }) => {
       if (name === 'self') return
       console.log('backing up key: ', name)


### PR DESCRIPTION
Because in the demo-mode we only use one Identity Box - it is intended that only the identities created and owned by the given user are backed up and not all of the identities.

The same applies for factory reset: when performing a factory reset, only user's own identities should be removed from the idbox and not all the identities.

> All this become less relevant when we start using separate idboxes for each user.