### PR TITLE
Uses "id" instead of "name" when creating image anchors in Markdown files

### DIFF
--- a/workspaces/homepage/src/pages/beta/experienceIdBox.md
+++ b/workspaces/homepage/src/pages/beta/experienceIdBox.md
@@ -12,7 +12,7 @@ For this purpose, specially for our early adopters, we created a *virtual* Ident
 
 When you start your IdentityBox app for the first time, you will be asked to scan your Identity Box's QRCode in order to establish a one-to-one connection between your Identity Box app and your Identity Box:
 
-<a name="figure-1"></a> 
+<a id="figure-1"></a> 
 <div class="flex-wrap">
 <div class="bordered-content-300">
   <img alt="Scan IdentityBox QRCode" src="assets/ExperienceIdBox-assets/ConnectToIdBox.png" />
@@ -22,7 +22,7 @@ When you start your IdentityBox app for the first time, you will be asked to sca
 
 Here, we want you to use our virtual Identity Box by scanning the following QRCode:
 
-<a name="figure-2"></a> 
+<a id="figure-2"></a> 
 <div class="flex-wrap">
 <div style="width: 300px;">
   <img alt="Virtual IdentityBox QRCode" src="assets/ExperienceIdBox-assets/QRCodeStockholm.png" />
@@ -32,7 +32,7 @@ Here, we want you to use our virtual Identity Box by scanning the following QRCo
 
 After scanning this QRCode, you will be able to create your first identity. Identity App allows for multiple identities, here you create your very first one:
 
-<a name="figure-3"></a> 
+<a id="figure-3"></a> 
 <div class="flex-wrap">
 <div class="bordered-content-300">
   <img alt="Create First Identity" src="assets/ExperienceIdBox-assets/CreateFirstIdentity.png"/>
@@ -47,7 +47,7 @@ Enter your first identity name and tap _Create_.
 
 After your first identity is successfully created, you will see the following screen (here I used the name *Zygfryd*):
 
-<a name="figure-4"></a> 
+<a id="figure-4"></a> 
 <div class="flex-wrap">
 <div class="bordered-content-300">
   <img alt="Current Identity View" src="assets/ExperienceIdBox-assets/Zygfryd.png"/>
@@ -57,7 +57,7 @@ After your first identity is successfully created, you will see the following sc
 
 You can now also open *Address Book* tab, to see your own, and your peer identities:
 
-<a name="figure-5"></a> 
+<a id="figure-5"></a> 
 <div class="flex-wrap">
 <div class="bordered-content-300">
   <img alt="Address Book" src="assets/ExperienceIdBox-assets/AddressBook.png"/>
@@ -70,7 +70,7 @@ identity with your peers by letting them scan the QRCode visible in the Identity
 
 You add peer identities to your address book by scanning the QRCode of your peer from the Identity tab and then by adding a descriptive name for your new *contact* - this new name never leaves your mobile.
 
-<a name="figure-6"></a> 
+<a id="figure-6"></a> 
 <div class="scrollable flex-wrap responsive">
 <div class="bordered-content-600">
   <img alt="Adding Peer Identity" src="assets/ExperienceIdBox-assets/NewPeerIdentity.png"/>
@@ -82,7 +82,7 @@ You add peer identities to your address book by scanning the QRCode of your peer
 
 In order to create another identity (i.e. your own identity) tap on the _Create New Identity_ icon in the top-right part of the navigation bar in the _Address Book_ tab:
 
-<a name="figure-7"></a> 
+<a id="figure-7"></a> 
 <div class="scrollable flex-wrap responsive">
 <div class="bordered-content-600">
   <img alt="Creating a new Identity" src="assets/ExperienceIdBox-assets/CreateNewIdentity.png"/>
@@ -94,7 +94,7 @@ In order to create another identity (i.e. your own identity) tap on the _Create 
 
 Finally, you can also delete identity by first tapping on the given identity in the _Address Book_ tab and then by tapping on _Delete this identity_ button. This works the same way for both you own identities and you peer identities, except that when you delete your own identity, it is also removed from your identity box.
 
-<a name="figure-8"></a> 
+<a id="figure-8"></a> 
 <div class="scrollable flex-wrap responsive">
 <div class="bordered-content-600">
   <img alt="Identity Details and deleting identities" src="assets/ExperienceIdBox-assets/IdentityDetails.png"/>

--- a/workspaces/homepage/src/pages/user/01_welcome.md
+++ b/workspaces/homepage/src/pages/user/01_welcome.md
@@ -26,7 +26,7 @@ Let's take a look how distributed storage infrastructure may change the way we d
 
 As already mentioned above, in the data storage playground, the dominating role is played by big data storage providers, like Amazon, Google, or Dropbox, to name a few most prominent. Lots of **our** data is also stored by the state, healthcare organizations, financial institutions, and corporations in general. In many cases, the owner of the data does not have any control of data, often not even being able to access it. All the world data are either kept by institutions that we do not trust, or sparingly distributed over very few data centers. [Figure 1](#figure-1) depicts the current situation:
 
-<a name="figure-1"></a> 
+<a id="figure-1"></a> 
 <div class="flex-wrap">
 <div class="bordered-content">
   <img alt="Current Situation" src="images/CurrentSituation.png"/>
@@ -40,7 +40,7 @@ The current situation has one more disadvantage. Every institution storing the d
 
 A more intuitive arrangement would be to store the data by the data owner - the user -  as presented in [Figure 2](#figure-2).
 
-<a name="figure-2"></a> 
+<a id="figure-2"></a> 
 <div class="flex-wrap">
 <div class="bordered-content">
   <img alt="User in control" src="images/DesiredSituation.png"/>
@@ -52,7 +52,7 @@ Here, we see that the user is in control, but we may also immediately realize a 
 
 A final proposal would be that all users, but also institutions, some of them storing the data on behalf of users, all participate in one overlay P2P network ([Figure 3](#figure-3)).
 
-<a name="figure-3"></a> 
+<a id="figure-3"></a> 
 <div class="flex-wrap">
 <div class="bordered-content">
   <img alt="P2P Network" src="images/OverlayNetwork.png"/>

--- a/workspaces/homepage/src/pages/user/02-automatic-backups/automatic-backups.md
+++ b/workspaces/homepage/src/pages/user/02-automatic-backups/automatic-backups.md
@@ -37,7 +37,7 @@ After you enable backups, we will create a new backup every time you add or remo
 
 Backup options are available in the _Settings_ tab:
 
-<a name="figure-1"></a> 
+<a id="figure-1"></a> 
 <div class="flex-wrap">
 <div class="bordered-content-300">
   <img alt="Settings" src="assets/AutomaticBackups-assets/Settings.png" />
@@ -47,7 +47,7 @@ Backup options are available in the _Settings_ tab:
 
 Here, you can enable automatic backups and after short while the backup will be created, stored on your Identity Box, and the passphrase mnemonic will be presented to you:
 
-<a name="figure-2"></a> 
+<a id="figure-2"></a> 
 <div class="flex-wrap">
 <div class="bordered-content-300">
   <img alt="Passphrase mnemonic" src="assets/AutomaticBackups-assets/Mnemonic.png" />
@@ -57,7 +57,7 @@ Here, you can enable automatic backups and after short while the backup will be 
 
 To, test your new backup, you can now perform the factory reset:
 
-<a name="figure-3"></a> 
+<a id="figure-3"></a> 
 <div class="flex-wrap">
 <div class="bordered-content-300">
   <img alt="Factory Reset" src="assets/AutomaticBackups-assets/Reset.png" />
@@ -67,7 +67,7 @@ To, test your new backup, you can now perform the factory reset:
 
 after which, you will need re-establish the connection with your Identity Box, by scanning its QRCode again:
 
-<a name="figure-4"></a> 
+<a id="figure-4"></a> 
 <div class="flex-wrap">
 <div class="bordered-content-300">
   <img alt="Scan Identity Box QRCode" src="assets/AutomaticBackups-assets/ScanIdBox.png" />
@@ -77,7 +77,7 @@ after which, you will need re-establish the connection with your Identity Box, b
 
 After connecting to your Identity Box, the app will check if any backups are available on it, and - if so - it will give you an option to _Restore from backup..._:
 
-<a name="figure-5"></a> 
+<a id="figure-5"></a> 
 <div class="flex-wrap">
 <div class="bordered-content-300">
   <img alt="Restore from backup" src="assets/AutomaticBackups-assets/RestoreFromBackup.png" />
@@ -87,7 +87,7 @@ After connecting to your Identity Box, the app will check if any backups are ava
 
 After selecting _Restore from backup..._ you will be asked to enter your passphrase mnemonic (the same you safely recorded in the previous step):
 
-<a name="figure-6"></a> 
+<a id="figure-6"></a> 
 <div class="flex-wrap">
 <div class="bordered-content-300">
   <img alt="Enter passphrase mnemonic" src="assets/AutomaticBackups-assets/EnterMnemonic.png" />
@@ -97,7 +97,7 @@ After selecting _Restore from backup..._ you will be asked to enter your passphr
 
 You confirm with _Done_ button on the keyboard. The integrity of your mnemonic will be checked by the app, and if the mnemonic appears to be correct, the _Restore_ button will be enabled.
 
-<a name="figure-7"></a> 
+<a id="figure-7"></a> 
 <div class="flex-wrap">
 <div class="bordered-content-300">
   <img alt="Passphrase mnemonic correct" src="assets/AutomaticBackups-assets/MnemonicCorrect.png" />
@@ -107,7 +107,7 @@ You confirm with _Done_ button on the keyboard. The integrity of your mnemonic w
 
 If the integrity check fails for any reason, you will receive feedback and opportunity to correct the mnemonic before you can proceed:
 
-<a name="figure-8"></a> 
+<a id="figure-8"></a> 
 <div class="flex-wrap">
 <div class="bordered-content-300">
   <img alt="Passphrase mnemonic incorrect" src="assets/AutomaticBackups-assets/MnemonicIncorrect.png" />
@@ -117,7 +117,7 @@ If the integrity check fails for any reason, you will receive feedback and oppor
 
 Notice that the fact that the integrity of the mnemonic has been confirmed does not mean that the backup kept on your Identity Box corresponds to this mnemonic - this will be checked just after you tap on _Restore_. If the backup found on the device does not match your passphrase mnemonic, it will be communicated to the user:
 
-<a name="figure-9"></a> 
+<a id="figure-9"></a> 
 <div class="flex-wrap">
 <div class="bordered-content-300">
   <img alt="No backup for the given passphrase mnemonic" src="assets/AutomaticBackups-assets/SomethingWrong.png" />
@@ -127,7 +127,7 @@ Notice that the fact that the integrity of the mnemonic has been confirmed does 
 
 On the other hand, when there is a backup on your Identity Box that corresponds to the passphrase mnemonic you entered, your address book will be correctly restored:
 
-<a name="figure-10"></a> 
+<a id="figure-10"></a> 
 <div class="flex-wrap">
 <div class="bordered-content-300">
   <img alt="Restoring successful" src="assets/AutomaticBackups-assets/RestoringSuccess.png" />


### PR DESCRIPTION
When we put figures in our markdown files we create anchors so that we can refer to them later. For instance, when having an image that we want to refer to as "Figure 1" and use [Figure 1](#figure-1) in a markdown file, we used to add the following anchor:

```html
<a name="figure-1"></a>
```

And it seem to work, except for when deployed with Gatsby, we sometimes get inconsistent behavior: after reloading the page some of the "Figure-x" links seem to be broken. Maybe this something specific to Gatsby, but it seems that using `id` in place of `name` is more reliable.

This seems to be more reliable way to make the anchors work on the deployed site