### PR TITLE
Adds missing instruction to get started

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -11,6 +11,7 @@ local environment:
 
 ```bash
 » yarn install
+» yarn setup:dev
 » yarn test
 » (cd workspaces/homepage && yarn develop)
 # or to get everything like in production


### PR DESCRIPTION
Without this, unit tests fail after clean checkout.