### PR TITLE
Allow IPFS node to run on a different host

### DIFF
--- a/workspaces/idservice/README.md
+++ b/workspaces/idservice/README.md
@@ -27,7 +27,7 @@ This is the file where your telepath configuration is kept. The included `telepa
 can be used for development (either locally or on your idbox), but should be removed before
 launching the actual service so that a fresh telepath configuration is created.
 
-## Required environment variables
+## Environment variables
 
 IdService assume some environment variables to be set.
 

--- a/workspaces/idservice/README.md
+++ b/workspaces/idservice/README.md
@@ -31,9 +31,13 @@ launching the actual service so that a fresh telepath configuration is created.
 
 IdService assume some environment variables to be set.
 
-### IPFS_PATH
+### IPFS environment variables
 
 `IPFS_PATH` needs to point to the IPFS data directory. On the local machine this is usually `$HOME/.ipfs`.
+
+`IPFS_ADDR` contains the address of the IPFS host. This needs to conform to the
+[multiaddr](https://multiformats.io/multiaddr/) format. When this environment
+variable is not set, the address will default to `/ip4/127.0.0.1/tcp/5001`.
 
 ### Automatic backup
 

--- a/workspaces/idservice/src/identity/IdentityProvider.js
+++ b/workspaces/idservice/src/identity/IdentityProvider.js
@@ -11,7 +11,7 @@ class IdentityProvider {
   id
 
   constructor () {
-    this.ipfs = ipfsClient('/ip4/127.0.0.1/tcp/5001')
+    this.ipfs = ipfsClient(process.env.IPFS_ADDR || '/ip4/127.0.0.1/tcp/5001')
   }
 
   createNew = async ({

--- a/workspaces/nameservice/src/entry-point/NameService.js
+++ b/workspaces/nameservice/src/entry-point/NameService.js
@@ -5,7 +5,7 @@ import { StateSerializer } from '@identity-box/utils'
 const PUBLISH_INTERVAL = 10000
 
 class NameService {
-  ipfs = ipfsClient('/ip4/127.0.0.1/tcp/5001')
+  ipfs = ipfsClient(process.env.IPFS_ADDR || '/ip4/127.0.0.1/tcp/5001')
   serializer
   interval
   identities

--- a/workspaces/nameservice/tests/entry-point/NameService.test.js
+++ b/workspaces/nameservice/tests/entry-point/NameService.test.js
@@ -94,8 +94,15 @@ describe('Name Service', () => {
       expect(response.body.message).toBe('unknown-method')
     })
 
-    it('creates ipfs client interface with correct api url', () => {
+    it('creates ipfs client interface with default api address', () => {
       expect(apiUrl).toBe('/ip4/127.0.0.1/tcp/5001')
+    })
+
+    it('creates ipfs client interface with custom api address', () => {
+      process.env.IPFS_ADDR = '/dns4/some.ipfs.host/tcp/5001'
+      new NameService() // eslint-disable-line no-new
+      expect(apiUrl).toBe(process.env.IPFS_ADDR)
+      delete process.env.IPFS_ADDR
     })
 
     it('returns ipns name and cid requested to be published in publish-name request', async () => {


### PR DESCRIPTION
Useful when running IPFS in a different docker container than the nameservice and idservice. Host is configured using the IPFS_ADDR environment variable.