### PR TITLE
Allow nameservice to run on a different host

### DIFF
--- a/workspaces/idservice/README.md
+++ b/workspaces/idservice/README.md
@@ -39,6 +39,11 @@ IdService assume some environment variables to be set.
 [multiaddr](https://multiformats.io/multiaddr/) format. When this environment
 variable is not set, the address will default to `/ip4/127.0.0.1/tcp/5001`.
 
+### IDBOX_NAMESERVICE_URL
+
+`IDBOX_NAMESERVICE_URL` contains the URL where the name service is
+listening. When this environment variable is not set, the URL will default to `http://localhost:3100`.
+
 ### Automatic backup
 
 For the automatic backups functionality, IdService requires two environment variables to be set: `IDBOX_BACKUP` holding the absolute path

--- a/workspaces/idservice/src/services/IPNSPubSub.js
+++ b/workspaces/idservice/src/services/IPNSPubSub.js
@@ -1,6 +1,7 @@
 import got from 'got'
 
-const nameServiceUrl = 'http://localhost:3100/'
+const nameServiceUrl =
+  process.env.IDBOX_NAMESERVICE_URL || 'http://localhost:3100/'
 
 const sendCommandToNameService = json => {
   return got(nameServiceUrl, {


### PR DESCRIPTION
Can be configured using the IDBOX_NAMESERVICE_URL environment variable.