### PR TITLE
Adds 3rd party service registration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 node_modules
 coverage/
+.fixtures
 .DS_Store
 yarn-error.log
 

--- a/workspaces/idservice/demo-node-ipc/node-ipc-client.js
+++ b/workspaces/idservice/demo-node-ipc/node-ipc-client.js
@@ -1,37 +1,76 @@
 import ipc from 'node-ipc'
+import commander from 'commander'
 
-ipc.config.appspace = 'crocs.'
-ipc.config.id = 'authentication-service'
-ipc.config.retry = 1000
+const program = new commander.Command()
 
-ipc.connectTo(
-  ipc.config.id,
-  () => {
-    ipc.of[ipc.config.id].on(
-      'connect',
-      () => {
-        ipc.log(`## connected to ${ipc.config.appspace}${ipc.config.id} ##`)
-        ipc.of[ipc.config.id].emit(
-          'message',
-          {
-            from: 'idservice',
-            message: 'hello'
-          }
-        )
-      }
-    )
-    ipc.of[ipc.config.id].on(
-      'disconnect',
-      () => {
-        ipc.log(`disconnected from ${ipc.config.appspace}${ipc.config.id}`)
-      }
-    )
-    ipc.of[ipc.config.id].on(
-      'message',
-      (data) => {
-        ipc.log(`got a message from ${ipc.config.appspace}${ipc.config.id}: `, data)
-      }
-    )
-    console.log(ipc.of[ipc.config.id].destroy)
+const startClientIPC = ({ serviceNamespace, serviceName }) => {
+  ipc.config.retry = 1000
+
+  const socketName = `${serviceNamespace}.${serviceName}`
+
+  ipc.connectTo(
+    socketName,
+    `${ipc.config.socketRoot}${serviceNamespace}.${serviceName}`,
+    () => {
+      ipc.of[socketName].on(
+        'connect',
+        () => {
+          ipc.log(`## connected to ${serviceNamespace}.${serviceName} ##`)
+          ipc.of[socketName].emit(
+            'message',
+            {
+              id: 'idservice',
+              message: `hello [${serviceNamespace}.${serviceName}]`
+            }
+          )
+        }
+      )
+      ipc.of[socketName].on(
+        'disconnect',
+        () => {
+          ipc.log(`disconnected from ${serviceNamespace}.${serviceName}`)
+        }
+      )
+      ipc.of[socketName].on(
+        'message',
+        (data) => {
+          ipc.log(`got a message from ${serviceNamespace}.${serviceName}: `, data)
+        }
+      )
+      console.log(ipc.of[socketName].destroy)
+    }
+  )
+}
+
+const connectTo = (endPoint) => {
+  const [serviceNamespace, serviceName] = endPoint.split('.')
+  if (serviceName === undefined || serviceName.length === 0) {
+    console.log('missing service name: the path should be in the format: service-namespace.service-name')
+    return false
   }
-)
+  console.log(`Using socket path: ${ipc.config.socketRoot}${endPoint}`)
+  startClientIPC({ serviceNamespace, serviceName })
+}
+
+const run = async cmdObj => {
+  const { endPoint1, endPoint2 } = cmdObj
+  ipc.log('============ Service 1 ================')
+  connectTo(endPoint1)
+
+  if (endPoint2) {
+    ipc.log('============ Service 2 ================')
+    connectTo(endPoint2)
+  }
+}
+
+async function main () {
+  program
+    .version('0.1.0')
+    .requiredOption('-1, --end-point-1 <path>', 'point separated service path for service-1: service-name-space.service-name, eg. crocs.authentication-service')
+    .option('-2, --end-point-2 <path>', '[optional] point separated service path for service-2: service-name-space.service-name, eg. crocs.name-service')
+    .action(run)
+
+  await program.parse(process.argv)
+}
+
+main()

--- a/workspaces/idservice/demo-node-ipc/node-ipc-client.js
+++ b/workspaces/idservice/demo-node-ipc/node-ipc-client.js
@@ -1,0 +1,37 @@
+import ipc from 'node-ipc'
+
+ipc.config.appspace = 'crocs.'
+ipc.config.id = 'authentication-service'
+ipc.config.retry = 1000
+
+ipc.connectTo(
+  ipc.config.id,
+  () => {
+    ipc.of[ipc.config.id].on(
+      'connect',
+      () => {
+        ipc.log(`## connected to ${ipc.config.appspace}${ipc.config.id} ##`)
+        ipc.of[ipc.config.id].emit(
+          'message',
+          {
+            from: 'idservice',
+            message: 'hello'
+          }
+        )
+      }
+    )
+    ipc.of[ipc.config.id].on(
+      'disconnect',
+      () => {
+        ipc.log(`disconnected from ${ipc.config.appspace}${ipc.config.id}`)
+      }
+    )
+    ipc.of[ipc.config.id].on(
+      'message',
+      (data) => {
+        ipc.log(`got a message from ${ipc.config.appspace}${ipc.config.id}: `, data)
+      }
+    )
+    console.log(ipc.of[ipc.config.id].destroy)
+  }
+)

--- a/workspaces/idservice/demo-node-ipc/node-ipc-server.js
+++ b/workspaces/idservice/demo-node-ipc/node-ipc-server.js
@@ -1,0 +1,25 @@
+import ipc from 'node-ipc'
+
+ipc.config.appspace = 'crocs.'
+ipc.config.id = 'authentication-service'
+ipc.config.retry = 1500
+
+ipc.serve(
+  () => {
+    ipc.server.on(
+      'message',
+      (data, socket) => {
+        ipc.server.emit(
+          socket,
+          'message',
+          {
+            from: `${ipc.config.appspace}${ipc.config.id}`,
+            message: data.message + ' world!'
+          }
+        )
+      }
+    )
+  }
+)
+
+ipc.server.start()

--- a/workspaces/idservice/demo-node-ipc/node-ipc-server.js
+++ b/workspaces/idservice/demo-node-ipc/node-ipc-server.js
@@ -1,25 +1,51 @@
 import ipc from 'node-ipc'
+import commander from 'commander'
 
-ipc.config.appspace = 'crocs.'
-ipc.config.id = 'authentication-service'
-ipc.config.retry = 1500
+const program = new commander.Command()
 
-ipc.serve(
-  () => {
-    ipc.server.on(
-      'message',
-      (data, socket) => {
-        ipc.server.emit(
-          socket,
-          'message',
-          {
-            from: `${ipc.config.appspace}${ipc.config.id}`,
-            message: data.message + ' world!'
-          }
-        )
-      }
-    )
+const setupIPC = ({ serviceNamespace, serviceName }) => {
+  ipc.config.appspace = `${serviceNamespace}.`
+  ipc.config.id = serviceName
+  ipc.config.retry = 1500
+
+  ipc.serve(
+    () => {
+      ipc.server.on(
+        'message',
+        (data, socket) => {
+          ipc.server.emit(
+            socket,
+            'message',
+            {
+              id: `${ipc.config.appspace}${ipc.config.id}`,
+              message: data.message + ' world!'
+            }
+          )
+        }
+      )
+    }
+  )
+}
+
+const run = async cmdObj => {
+  const { endPoint } = cmdObj
+  const [serviceNamespace, serviceName] = endPoint.split('.')
+  if (serviceName === undefined || serviceName.length === 0) {
+    console.log('missing service name: the path should be in the format: service-namespace.service-name')
+    process.exit(1)
   }
-)
+  console.log(`Using socket path: ${ipc.config.socketRoot}${endPoint}`)
+  setupIPC({ serviceNamespace, serviceName })
+  ipc.server.start()
+}
 
-ipc.server.start()
+async function main () {
+  program
+    .version('0.1.0')
+    .requiredOption('-e, --end-point <path>', 'point separated service path: service-name-space.service-name, eg. crocs.authentication-service')
+    .action(run)
+
+  await program.parse(process.argv)
+}
+
+main()

--- a/workspaces/idservice/ecosystem.config.js
+++ b/workspaces/idservice/ecosystem.config.js
@@ -2,7 +2,6 @@ module.exports = {
   apps: [{
     name: 'idservice',
     script: './node_modules/.bin/idservice',
-    args: 'zdpuAnNHdFqw4FQkBgSTC3kKCHrHyFHyEBbeuCafwV2JkvPc6',
     instances: 1,
     autorestart: false,
     watch: false,

--- a/workspaces/idservice/package.json
+++ b/workspaces/idservice/package.json
@@ -39,6 +39,7 @@
     "got": "^10.6.0",
     "ipfs-http-client": "^42.0.0",
     "libp2p-crypto": "^0.17.3",
+    "node-ipc": "^9.1.1",
     "qrcode-terminal": "^0.12.0",
     "tweetnacl": "^1.0.3"
   },

--- a/workspaces/idservice/package.json
+++ b/workspaces/idservice/package.json
@@ -45,5 +45,8 @@
   },
   "publishConfig": {
     "access": "public"
+  },
+  "devDependencies": {
+    "fs-extra": "^8.1.0"
   }
 }

--- a/workspaces/idservice/src/services/ServiceRegistry.js
+++ b/workspaces/idservice/src/services/ServiceRegistry.js
@@ -1,0 +1,44 @@
+import path from 'path'
+import { StateSerializer } from '@identity-box/utils'
+
+class ServiceRegistry {
+  services = []
+  stateSerializer
+
+  constructor ({ serializerFilePath } = {}) {
+    const filePath = serializerFilePath || path.resolve(process.cwd(), 'Services.json')
+    this.stateSerializer = new StateSerializer(filePath)
+    this.services = this.stateSerializer.read() || []
+  }
+
+  checkPath = path => {
+    if (!path) {
+      throw new Error('Attemting to register a service without providing path!')
+    }
+
+    const [serviceNamespace, serviceName, ...rest] = path.split('.')
+
+    if (rest.length > 0) {
+      throw new Error('Too many service path components!')
+    }
+
+    if (serviceNamespace === undefined || serviceNamespace.length === 0) {
+      throw new Error('Missing service namespace in path!')
+    }
+
+    if (serviceName === undefined || serviceName.length === 0) {
+      throw new Error('Missing service name in path!')
+    }
+  }
+
+  register = servicePath => {
+    this.checkPath(servicePath)
+    if (this.services.includes(servicePath)) {
+      throw new Error('Service with given path already exists!')
+    }
+    this.services.push(servicePath)
+    this.stateSerializer.write(this.services)
+  }
+}
+
+export { ServiceRegistry }

--- a/workspaces/idservice/tests/services/ServiceRegistry.test.js
+++ b/workspaces/idservice/tests/services/ServiceRegistry.test.js
@@ -1,0 +1,180 @@
+import { ServiceRegistry } from '../../src/services/ServiceRegistry'
+
+import fs from 'fs-extra'
+import path from 'path'
+
+describe('ServiceRegistry', () => {
+  const servicePath = 'service-namespace.servicename'
+  const anotherServicePath = 'another-service-namespace.servicename'
+
+  const serializerFileDir = path.resolve(process.cwd(), '.fixtures', 'idservice')
+  const serializerFilePath = path.resolve(serializerFileDir, 'Service.json')
+
+  let serviceRegistry
+
+  const prepareFixtureFile = () => {
+    fs.ensureDirSync(serializerFileDir)
+    fs.removeSync(serializerFilePath)
+  }
+
+  beforeEach(() => {
+    prepareFixtureFile()
+    serviceRegistry = new ServiceRegistry({
+      serializerFilePath
+    })
+  })
+
+  afterEach(() => {
+    fs.removeSync(serializerFilePath)
+  })
+
+  it('does not have any services registred when created for the first time', () => {
+    expect(serviceRegistry.services).toEqual([])
+  })
+
+  it('allows registering a new service endpoit', () => {
+    serviceRegistry.register(servicePath)
+
+    expect(serviceRegistry.services).toEqual([servicePath])
+  })
+
+  it('maintains the order of registered services in the returned array', () => {
+    serviceRegistry.register(servicePath)
+    serviceRegistry.register(anotherServicePath)
+
+    expect(serviceRegistry.services).toEqual([servicePath, anotherServicePath])
+  })
+
+  describe('checking service path format', () => {
+    const pathExists = Symbol('path exists')
+    const noPath = Symbol('no path')
+    const emptyPath = Symbol('empty path')
+    const noServiceName = Symbol('no service name')
+    const noServiceNamespace = Symbol('no service namespace')
+    const tooManyPathComponents = Symbol('too many path components')
+
+    const errors = {
+      [pathExists]: 'Service with given path already exists!',
+      [noPath]: 'Attemting to register a service without providing path!',
+      [emptyPath]: 'Attemting to register a service with empty path!',
+      [noServiceName]: 'Missing service name in path!',
+      [noServiceNamespace]: 'Missing service namespace in path!',
+      [tooManyPathComponents]: 'Too many service path components!'
+    }
+
+    it('throws when trying to register existing path', () => {
+      const error = new Error(errors[pathExists])
+
+      serviceRegistry.register(servicePath)
+
+      expect(() => serviceRegistry.register(servicePath)).toThrow(error)
+    })
+
+    it('throws when path is not provided', () => {
+      const error = new Error(errors[noPath])
+
+      expect(() => serviceRegistry.register()).toThrow(error)
+    })
+
+    it('throws when path is provided but empty', () => {
+      const error = new Error(errors[noPath])
+
+      expect(() => serviceRegistry.register('')).toThrow(error)
+    })
+
+    it('throws when path does not include service name', () => {
+      const error = new Error(errors[noServiceName])
+
+      const serviceRegistry = new ServiceRegistry()
+
+      expect(() => serviceRegistry.register('serviceNamespace')).toThrow(error)
+      expect(() => serviceRegistry.register('serviceNamespace.')).toThrow(error)
+    })
+
+    it('throws when path does not include service namespace', () => {
+      const error = new Error(errors[noServiceNamespace])
+
+      expect(() => serviceRegistry.register('.serviceName')).toThrow(error)
+    })
+
+    it('throws when path includes too many path components', () => {
+      const error = new Error(errors[tooManyPathComponents])
+
+      expect(() => serviceRegistry.register('a.b.c.d')).toThrow(error)
+    })
+  })
+
+  describe('preserving state', () => {
+    const readSerializedState = () => {
+      try {
+        return JSON.parse(fs.readFileSync(serializerFilePath))
+      } catch {
+        return []
+      }
+    }
+
+    beforeEach(() => {
+      console.error = jest.fn()
+    })
+
+    afterEach(() => {
+      console.error.mockRestore()
+    })
+
+    it('writes registered services to a file when adding a new service', () => {
+      serviceRegistry.register(servicePath)
+
+      expect(readSerializedState()).toEqual(serviceRegistry.services)
+    })
+
+    it('writes more registered services to a file when adding a new service', () => {
+      serviceRegistry.register(servicePath)
+      serviceRegistry.register(anotherServicePath)
+
+      expect(readSerializedState()).toEqual(serviceRegistry.services)
+    })
+
+    it('restores previously registred services from a file', () => {
+      const serializedState = [
+        servicePath,
+        anotherServicePath
+      ]
+      fs.writeFileSync(serializerFilePath, JSON.stringify(serializedState))
+
+      serviceRegistry = new ServiceRegistry({
+        serializerFilePath
+      })
+
+      expect(serviceRegistry.services).toEqual(serializedState)
+    })
+
+    it('restores registred services to an empty list if file does not exist', () => {
+      serviceRegistry = new ServiceRegistry({
+        serializerFilePath
+      })
+
+      expect(serviceRegistry.services).toEqual([])
+    })
+
+    it('restores registred services to an empty list if file exists but is empty', () => {
+      fs.ensureFileSync(serializerFilePath)
+
+      serviceRegistry = new ServiceRegistry({
+        serializerFilePath
+      })
+
+      expect(serviceRegistry.services).toEqual([])
+    })
+
+    it('restores registred services to an empty list if file exists and is empty list', () => {
+      const serializedState = []
+      fs.writeFileSync(serializerFilePath, JSON.stringify(serializedState))
+
+      serviceRegistry = new ServiceRegistry({
+        serializerFilePath
+      })
+
+      expect(serviceRegistry.services).toEqual([])
+    })
+  })
+})

--- a/workspaces/idservice/tests/telepath/Telepath.test.js
+++ b/workspaces/idservice/tests/telepath/Telepath.test.js
@@ -1,6 +1,6 @@
 import fs from 'fs'
 import base64url from 'base64url'
-import { Telepath } from './Telepath'
+import { Telepath } from '../../src/telepath'
 
 jest.mock('fs')
 

--- a/workspaces/nameservice/src/entry-point/NameService.js
+++ b/workspaces/nameservice/src/entry-point/NameService.js
@@ -12,7 +12,7 @@ class NameService {
 
   constructor () {
     this.serializer = new StateSerializer(path.resolve(process.cwd(), 'Identities.json'))
-    this.identities = this.serializer.read()
+    this.identities = this.serializer.read() || {}
     if (Object.keys(this.identities).length > 0) {
       this.interval = setInterval(this.publishHandler, PUBLISH_INTERVAL)
     }

--- a/workspaces/utils/source/state-serializer/StateSerializer.js
+++ b/workspaces/utils/source/state-serializer/StateSerializer.js
@@ -14,14 +14,14 @@ class StateSerializer {
 
   read = () => {
     if (!fs.existsSync(this.path)) {
-      return {}
+      return undefined
     }
     try {
       const stateStr = fs.readFileSync(this.path, 'UTF-8')
       return JSON.parse(stateStr)
     } catch (e) {
       console.error(e)
-      return {}
+      return undefined
     }
   }
 }

--- a/workspaces/utils/tests/state-serializer/StateSerializer.test.js
+++ b/workspaces/utils/tests/state-serializer/StateSerializer.test.js
@@ -14,9 +14,9 @@ describe('StateSerializer', () => {
     fs.existsSync = jest.fn().mockReturnValue(true)
   })
 
-  it('returns empty object if file does not exist', () => {
+  it('returns undefined if file does not exist', () => {
     fs.existsSync = jest.fn().mockReturnValue(false)
-    expect(serializer.read()).toEqual({})
+    expect(serializer.read()).not.toBeDefined()
   })
 
   it('writes state to a file as JSON string', () => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -8722,6 +8722,11 @@ duplexify@^4.1.1:
     readable-stream "^3.1.1"
     stream-shift "^1.0.0"
 
+easy-stack@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/easy-stack/-/easy-stack-1.0.0.tgz#12c91b3085a37f0baa336e9486eac4bf94e3e788"
+  integrity sha1-EskbMIWjfwuqM26UhurEv5Tj54g=
+
 ecc-jsbn@~0.1.1:
   version "0.1.2"
   resolved "https://registry.yarnpkg.com/ecc-jsbn/-/ecc-jsbn-0.1.2.tgz#3a83a904e54353287874c564b7549386849a98c9"
@@ -9386,6 +9391,11 @@ eval@^0.1.0, eval@^0.1.4:
   integrity sha512-npGsebJejyjMRnLdFu+T/97dnigqIU0Ov3IGrZ8ygd1v7RL1vGkEKtvyWZobqUH1AQgKlg0Yqqe2BtMA9/QZLw==
   dependencies:
     require-like ">= 0.1.1"
+
+event-pubsub@4.3.0:
+  version "4.3.0"
+  resolved "https://registry.yarnpkg.com/event-pubsub/-/event-pubsub-4.3.0.tgz#f68d816bc29f1ec02c539dc58c8dd40ce72cb36e"
+  integrity sha512-z7IyloorXvKbFx9Bpie2+vMJKKx1fH1EN5yiTfp8CiLOTptSYy1g8H4yDpGlEdshL1PBiFtBHepF2cNsqeEeFQ==
 
 event-source-polyfill@^1.0.12:
   version "1.0.12"
@@ -14521,6 +14531,18 @@ js-levenshtein@^1.1.3:
   resolved "https://registry.yarnpkg.com/js-levenshtein/-/js-levenshtein-1.1.6.tgz#c6cee58eb3550372df8deb85fad5ce66ce01d59d"
   integrity sha512-X2BB11YZtrRqY4EnQcLX5Rh373zbK4alC1FW7D7MBhL2gtcC17cTnr6DmfHZeS0s2rTHjUTMMHfG7gO8SSdw+g==
 
+js-message@1.0.5:
+  version "1.0.5"
+  resolved "https://registry.yarnpkg.com/js-message/-/js-message-1.0.5.tgz#2300d24b1af08e89dd095bc1a4c9c9cfcb892d15"
+  integrity sha1-IwDSSxrwjondCVvBpMnJz8uJLRU=
+
+js-queue@2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/js-queue/-/js-queue-2.0.0.tgz#362213cf860f468f0125fc6c96abc1742531f948"
+  integrity sha1-NiITz4YPRo8BJfxslqvBdCUx+Ug=
+  dependencies:
+    easy-stack "^1.0.0"
+
 js-sha3@~0.8.0:
   version "0.8.0"
   resolved "https://registry.yarnpkg.com/js-sha3/-/js-sha3-0.8.0.tgz#b9b7a5da73afad7dedd0f8c463954cbde6818840"
@@ -17027,6 +17049,15 @@ node-int64@^0.4.0:
   version "0.4.0"
   resolved "https://registry.yarnpkg.com/node-int64/-/node-int64-0.4.0.tgz#87a9065cdb355d3182d8f94ce11188b825c68a3b"
   integrity sha1-h6kGXNs1XTGC2PlM4RGIuCXGijs=
+
+node-ipc@^9.1.1:
+  version "9.1.1"
+  resolved "https://registry.yarnpkg.com/node-ipc/-/node-ipc-9.1.1.tgz#4e245ed6938e65100e595ebc5dc34b16e8dd5d69"
+  integrity sha512-FAyICv0sIRJxVp3GW5fzgaf9jwwRQxAKDJlmNFUL5hOy+W4X/I5AypyHoq0DXXbo9o/gt79gj++4cMr4jVWE/w==
+  dependencies:
+    event-pubsub "4.3.0"
+    js-message "1.0.5"
+    js-queue "2.0.0"
 
 node-libs-browser@^2.2.1:
   version "2.2.1"


### PR DESCRIPTION
This PR provides API for 3rd party service registration so that there is a uniform programatic way to register a 3rd party service. We expect that native Identity Box services (currently Name Service) will also switch to this registration method.

While introducing a uniform registration method, we also change the way services communicate. Because all services operate on the same machine, an interprocess communication based on Unix sockets seem to be an appropriate mechanism to make this communication light, fast, and secure.

We use [node-ipc](https://www.npmjs.com/package/node-ipc) as an abstraction for the socket communication between processes.