### PR TITLE
ci: enables caching dependencies

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -1,8 +1,8 @@
 # This workflow will do a clean install of node dependencies, build the source code and run tests across different versions of node
 # For more information see: https://help.github.com/actions/language-and-framework-guides/using-nodejs-with-github-actions
 
-# To get proper caching for monorepos we use actions/cache@master instead of actions/cache@1. Support for
-# monorepos will be available in actions/cache@2.
+# To get proper caching for monorepos we use actions/cache@eb78578266b7cec649ab65b6f1534bd6040c838b (from master branch) 
+# instead of actions/cache@1. Support for monorepos will be available in actions/cache@2.
 
 name: Node.js CI
 
@@ -28,7 +28,7 @@ jobs:
           node-version: ${{ matrix.node-version }}
       - name: restore lerna
         id: cache
-        uses: actions/cache@master
+        uses: actions/cache@eb78578266b7cec649ab65b6f1534bd6040c838b
         with:
           path: |
             node_modules

--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -29,7 +29,7 @@ jobs:
       with:
         path: |
           node_modules
-            */*/node_modules
+          */*/node_modules
         key: ${{ runner.os }}-${{ hashFiles('yarn.lock') }}
     - run: yarn setup:dev
     - run: yarn test

--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -11,7 +11,6 @@ on:
 
 jobs:
   build:
-
     runs-on: ubuntu-latest
 
     strategy:
@@ -19,19 +18,24 @@ jobs:
         node-version: [12.x]
 
     steps:
-    - uses: actions/checkout@v2
-    - name: Use Node.js ${{ matrix.node-version }}
-      uses: actions/setup-node@v1
-      with:
-        node-version: ${{ matrix.node-version }}
-    - name: restore lerna
-      uses: actions/cache@v1
-      with:
-        path: |
-          node_modules
-          */*/node_modules
-        key: ${{ runner.os }}-${{ hashFiles('yarn.lock') }}
-    - run: yarn setup:dev
-    - run: yarn test
-      env:
-        CI: true
+      - uses: actions/checkout@v2
+      - name: Use Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v1
+        with:
+          node-version: ${{ matrix.node-version }}
+      - name: restore lerna
+        id: cache
+        uses: actions/cache@v1
+        with:
+          path: |
+            node_modules
+            */*/node_modules
+          key: ${{ runner.os }}-${{ hashFiles('yarn.lock') }}
+      - name: Install Dependencies
+        if: steps.cache.outputs.cache-hit != 'true'
+        run: yarn
+      - name: Build local packages
+        run: yarn build
+      - run: yarn test
+        env:
+          CI: true

--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -1,6 +1,9 @@
 # This workflow will do a clean install of node dependencies, build the source code and run tests across different versions of node
 # For more information see: https://help.github.com/actions/language-and-framework-guides/using-nodejs-with-github-actions
 
+# To get proper caching for monorepos we use actions/cache@master instead of actions/cache@1. Support for
+# monorepos will be available in actions/cache@2.
+
 name: Node.js CI
 
 on:

--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -30,7 +30,7 @@ jobs:
           path: |
             node_modules
             */*/node_modules
-          key: ${{ runner.os }}-${{ hashFiles('yarn.lock') }}
+          key: m-${{ runner.os }}-${{ hashFiles('yarn.lock') }}
       - name: Install Dependencies
         if: steps.cache.outputs.cache-hit != 'true'
         run: yarn

--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -24,6 +24,13 @@ jobs:
       uses: actions/setup-node@v1
       with:
         node-version: ${{ matrix.node-version }}
+    - name: restore lerna
+      uses: actions/cache@v2
+      with:
+        path: |
+          node_modules
+            */*/node_modules
+        key: ${{ runner.os }}-${{ hashFiles('yarn.lock') }}
     - run: yarn setup:dev
     - run: yarn test
       env:

--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -25,7 +25,7 @@ jobs:
       with:
         node-version: ${{ matrix.node-version }}
     - name: restore lerna
-      uses: actions/cache@v2
+      uses: actions/cache@v1
       with:
         path: |
           node_modules

--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -25,12 +25,12 @@ jobs:
           node-version: ${{ matrix.node-version }}
       - name: restore lerna
         id: cache
-        uses: actions/cache@v1
+        uses: actions/cache@master
         with:
           path: |
             node_modules
             */*/node_modules
-          key: m-${{ runner.os }}-${{ hashFiles('yarn.lock') }}
+          key: n-${{ runner.os }}-${{ hashFiles('yarn.lock') }}
       - name: Install Dependencies
         if: steps.cache.outputs.cache-hit != 'true'
         run: yarn


### PR DESCRIPTION
To get proper caching for monorepos we use `actions/cache@eb78578266b7cec649ab65b6f1534bd6040c838b` (from master branch) instead of `actions/cache@1`. Support for monorepos will be available in `actions/cache@2`.

See also: https://github.com/actions/cache/pull/212.