### PR TITLE
identity-service: fix key path

### DIFF
--- a/workspaces/identity-service/source/services/IdentityProvider.js
+++ b/workspaces/identity-service/source/services/IdentityProvider.js
@@ -257,7 +257,7 @@ class IdentityProvider {
 
   getKeyPath = name => {
     const encodedName = base32encode(Buffer.from(name), 'RFC4648', { padding: false })
-    return path.join(process.env.IPFS_PATH, 'keystore', `key_${encodedName}`)
+    return path.join(process.env.IPFS_PATH, 'keystore', `key_${encodedName.toLowerCase()}`)
   }
 
   getBackupPath = (name, backupId) => {

--- a/workspaces/identity-service/tests/services/IdentityProvider.test.js
+++ b/workspaces/identity-service/tests/services/IdentityProvider.test.js
@@ -1,0 +1,20 @@
+import path from 'path'
+import base32encode from 'base32-encode'
+
+import { IdentityProvider } from '../../source/services/IdentityProvider'
+
+describe('Identity Provider', () => {
+  it('produces correct key path given a name', () => {
+    const ipfs = jest.fn()
+    process.env.IPFS_PATH = '/some-base-path'
+    const identityProvider = new IdentityProvider(ipfs)
+
+    const name = 'test-name'
+    const keyPath = identityProvider.getKeyPath(name)
+
+    const encodedName = base32encode(Buffer.from(name), 'RFC4648', { padding: false })
+    const expectedKeyPath = path.join(process.env.IPFS_PATH, 'keystore', `key_${encodedName.toLowerCase()}`)
+
+    expect(keyPath).toBe(expectedKeyPath)
+  })
+})


### PR DESCRIPTION
This PR fixes the improper case for the key name when exporting/importing keys.